### PR TITLE
Add logic to sync with host track (time_ms not just track number)

### DIFF
--- a/routes/helpers.js
+++ b/routes/helpers.js
@@ -21,7 +21,6 @@ const requestSpotifyAccessToken = async (req, code) => {
         const response = await axios.post('https://accounts.spotify.com/api/token', formData, options);
         // Store access_token and refresh_token in session
         req.session.access_token = response.data.access_token;
-        console.log(req.session.access_token);
         req.session.refresh_token = response.data.refresh_token;
         return true;
 

--- a/routes/playbackHelpers/playbackHelpers.js
+++ b/routes/playbackHelpers/playbackHelpers.js
@@ -1,3 +1,5 @@
+const axios = require('axios');
+
 /**
  * Takes in the spotifyApi instnance and a user's access token and retrieves their 
  *  current playback state.
@@ -20,15 +22,27 @@ const retrievePlaybackData = async (spotifyApi, accessToken) => {
 const playTrack = async (spotifyApi, accessToken, albumUri, trackNumber, trackTime) => {
     try {
         // Sets access token to the current user
-        spotifyApi.setAccessToken(accessToken);
-        const response = await spotifyApi.play({
+        // spotifyApi.setAccessToken(accessToken);
+        let trackData = {
             context_uri: albumUri,
             offset: {
                 position: trackNumber - 1,
-                position_ms: trackTime
+            },
+            position_ms: trackTime // Will need to calculate an offset to deal with network lag.
+        }
+        // Manually makes request, bug in node.js library
+        const response = await axios.put(
+            "https://api.spotify.com/v1/me/player/play",
+            trackData,
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${accessToken}`
+                }
             }
-        });
-        if (response.body == {});
+        );
+        // const response = await spotifyApi.play();
+        if (response.data == '');
         return true;
     } catch (err) {
         return false;


### PR DESCRIPTION
Will need to calcuate a network lag offset to then apply to the "play" function.

Had to work around a bug in web-spotify-api, namely not reading funciton fields correctly such that position_ms was never read from incoming requests. Submitted bug fixing pull request, will see if it goes through and update from there.